### PR TITLE
Support Latin 1 Supplement characters in query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forked-rql",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": "Sebastian Ruml",
   "contributors": [
     "Vladimir Dronnikov <dronnikov@gmail.com>"

--- a/parser.js
+++ b/parser.js
@@ -48,14 +48,14 @@ function parse(/*String|Object*/query, parameters){
 	}
 	if(query.indexOf("/") > -1){ // performance guard
 		// convert slash delimited text to arrays
-		query = query.replace(/[\+\*\$\-:\w%\._]*\/[\+\*\$\-:\w%\._\/]*/g, function(slashed){
-			return "(" + slashed.replace(/\//g, ",") + ")";
+	query = query.replace(/[\+\*\$\-:\w%\._]*\/[\+\*\$\-:\w%\._\/]*/g, function(slashed){
+		return "(" + slashed.replace(/\//g, ",") + ")";
 		});
 	}
 	// convert FIQL to normalized call syntax form
-	query = query.replace(/(\([\+\*\$\-:\w%\._,]+\)|[\+\*\$\-:\w%\._]*|)([<>!]?=(?:[\w]*=)?|>|<)(\([\+\*\$\-:\w%\._,]+\)|[\+\*\$\-:\w%\._]*|)/g,
-						// <---------       property        -----------><------  operator -----><----------------   value ------------------>
-			function(t, property, operator, value){
+	query = query.replace(/(\([\+\*\$\-:\w%\._,]+\)|[\+\*\$\-:\w%\._]*|)([<>!]?=(?:[\w]*=)?|>|<)(\([\+\*\$\-:\w\u00C0-\u00ff%\._,]+\)|[\+\*\$\-:\w\u00C0-\u00ff%\._]*|)/g,
+											// <---------       property        -----------><------  operator -----><------------------------------ value ------------------------------->
+	  function(t, property, operator, value){
 		if(operator.length < 3){
 			if(!operatorMap[operator]){
 				throw new URIError("Illegal operator " + operator);
@@ -70,7 +70,7 @@ function parse(/*String|Object*/query, parameters){
 	if(query.charAt(0)=="?"){
 		query = query.substring(1);
 	}
-	var leftoverCharacters = query.replace(/(\))|([&\|,])?([\+\*\$\-:\w%\._]*)(\(?)/g,
+	var leftoverCharacters = query.replace(/(\))|([&\|,])?([\+\*\$\-:\w\u00C0-\u00ff%\._]*)(\(?)/g,
 							//   <-closedParan->|<-delim-- propertyOrValue -----(> |
 		function(t, closedParan, delim, propertyOrValue, openParan){
 			if(delim){

--- a/test/query.js
+++ b/test/query.js
@@ -16,6 +16,7 @@ define(function (require) {
 				'a((b),c)': { name: 'and', args: [{ name: 'a', args: [ [ 'b' ], 'c' ]}]},
 				'a((b,c),d)': { name: 'and', args: [{ name: 'a', args: [ [ 'b', 'c' ], 'd' ]}]},
 				'a(b/c,d)': { name: 'and', args: [{ name: 'a', args: [ [ 'b', 'c' ], 'd' ]}]},
+				'a(b/c,ü)': {name: 'and', args: [{name: 'a', args: [['b', 'c'], 'ü']}]},
 				'a(b)&c(d(e))': { name: 'and', args:[
 					{ name: 'a', args: [ 'b' ]},
 					{ name: 'c', args: [ { name: 'd', args: [ 'e' ]} ]}
@@ -23,6 +24,7 @@ define(function (require) {
 			},
 			'dot-comparison': {
 				'foo.bar=3': { name: 'and', args: [{ name: 'eq', args: [ 'foo.bar', 3 ]}]},
+				'foo.bar=Ü': { name: 'and', args: [{name: 'eq', args: ['foo.bar', 'Ü']}]},
 				'select(sub.name)': {
 					name: 'and',
 					args: [ { name: 'select', args: [ 'sub.name' ]} ],
@@ -31,12 +33,16 @@ define(function (require) {
 			},
 			equality: {
 				'eq(a,b)': { name: 'and', args:[{ name: 'eq', args: [ 'a', 'b' ]}]},
+				'eq(a,ß)': { name: 'and', args: [{name: 'eq', args: ['a', 'ß']}]},
 				'a=eq=b': 'eq(a,b)',
+				'a=eq=ß': 'eq(a,ß)',
 				'a=b': 'eq(a,b)'
 			},
 			inequality: {
 				'ne(a,b)': { name: 'and', args: [{ name: 'ne', args: [ 'a', 'b' ]}]},
+				'ne(a,ü)': {name: 'and', args: [{ name: 'ne', args: ['a', 'ü'] }]},
 				'a=ne=b': 'ne(a,b)',
+				'a=ne=ä': 'ne(a,ä)',
 				'a!=b': 'ne(a,b)'
 			},
 			'less-than': {
@@ -68,7 +74,8 @@ define(function (require) {
 			},
 			'arbitrary FIQL desugaring': {
 				'a=b=c': { name: 'and', args: [{ name: 'b', args: [ 'a', 'c' ]}]},
-				'a(b=cd=e)': { name: 'and', args: [{ name: 'a', args: [{ name: 'cd', args: [ 'b', 'e' ]}]}]}
+				'a(b=cd=e)': { name: 'and', args: [{ name: 'a', args: [{ name: 'cd', args: [ 'b', 'e' ]}]}]},
+				'a(b=cd=å)': { name: 'and', args: [{ name: 'a', args: [{ name: 'cd', args: [ 'b', 'å' ]}]}]}
 			},
 			'and grouping': {
 				'a&b&c': { name: 'and', args: [ 'a', 'b', 'c' ]},
@@ -90,7 +97,8 @@ define(function (require) {
 			'string coercion': {
 				'a(string)': { name: 'and', args: [{ name: 'a', args: [ 'string' ]}]},
 				'a(string:b)': { name: 'and', args: [{ name: 'a', args: [ 'b' ]}]},
-				'a(string:1)': { name: 'and', args: [{ name: 'a', args: [ '1' ]}]}
+				'a(string:1)': { name: 'and', args: [{ name: 'a', args: [ '1' ]}]},
+				'a(string:ö)': {name: 'and', args: [{name: 'a', args: ['ö']}]}
 			},
 			'number coercion': {
 				'a(number)': { name: 'and', args: [{ name: 'a', args: [ 'number' ]}]},


### PR DESCRIPTION
Currently only query values that are in the Basic Latin alphabet (A-Z) are supported in the query string since the regex patterns are using word boundaries `\w` (equivalent to `[a-zA-Z0-9_]`). To also support letter characters from the [Latin 1 Supplement alphabet](https://en.wikipedia.org/wiki/Latin-1_Supplement_(Unicode_block)) in the query strings, the word boundaries were extended to also include the Unicode range (\u00C0-\u00ff).